### PR TITLE
feat: 答えを入力する部分をWysiwygエディターに変更。

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -13,6 +13,7 @@
     "@mantine/core": "^4.2.6",
     "@mantine/hooks": "^4.2.6",
     "@mantine/notifications": "^4.2.6",
+    "@mantine/rte": "^4.2.6",
     "@uiw/react-textarea-code-editor": "^2.0.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/package/src/components/EditStructuredData/EditFaqStructuredData.tsx
+++ b/package/src/components/EditStructuredData/EditFaqStructuredData.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
+import ReactQuill from 'react-quill';
 import { Button, Grid, Group, ScrollArea, TextInput, Title } from '@mantine/core';
 import { RichTextEditor } from '@mantine/rte';
 import ViewStructuredData from '~/components/common/ViewStructuredData';
 import FaqItem from '~/components/EditStructuredData/FaqItem';
 import { defaultfaqPageStructuredData } from '~/config/defaultStructuredData';
 import { FaqPageStructuredData } from '~/types/structuredData';
-import ReactQuill from 'react-quill';
+import { escapeHtml } from '~/utils/escapeHtml';
 
 const EditFaqstructuredData: React.FC = () => {
   const [structuredData, setStructuredData] = useState<FaqPageStructuredData>(defaultfaqPageStructuredData);
@@ -83,6 +84,20 @@ const EditFaqstructuredData: React.FC = () => {
     });
   };
 
+  // FAQの構造化データの中の答えのHTMLのエスケープ化を行う
+  const escapeAnswerHtml = structuredData.mainEntity.map((entity) => {
+    return {
+      ...entity,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: escapeHtml(entity.acceptedAnswer.text),
+      },
+    };
+  });
+
+  // プレビューに表示する構造化データの答えのみ上書きする
+  const newStructuredData = { ...structuredData, mainEntity: escapeAnswerHtml } as FaqPageStructuredData;
+
   return (
     <>
       <Title order={2}>FAQの構造化データを入力してください</Title>
@@ -110,7 +125,7 @@ const EditFaqstructuredData: React.FC = () => {
           )}
         </Grid.Col>
         <Grid.Col md={1} lg={2}>
-          <ViewStructuredData jsonString={structuredData} />
+          <ViewStructuredData structuredData={newStructuredData} />
         </Grid.Col>
       </Grid>
     </>

--- a/package/src/components/EditStructuredData/EditFaqStructuredData.tsx
+++ b/package/src/components/EditStructuredData/EditFaqStructuredData.tsx
@@ -25,22 +25,26 @@ const EditFaqstructuredData: React.FC = () => {
       <Title order={2}>FAQの構造化データを入力してください</Title>
       <Grid grow>
         <Grid.Col md={1} lg={2}>
-          <Title order={3}>質問</Title>
-          <TextInput
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(e)}
-            value={faqData.question}
-          />
-          <Title order={3}>答え</Title>
-          <RichTextEditor
-            controls={[
-              ['bold', 'link', 'underline', 'italic'],
-              ['unorderedList', 'orderedList'],
-              ['h1', 'h2', 'h3'],
-            ]}
-            ref={editorRef}
-            value={faqData.answer}
-            onChange={(value) => handleEditorChange(value)}
-          />
+          <div>
+            <Title order={3}>質問</Title>
+            <TextInput
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(e)}
+              value={faqData.question}
+            />
+          </div>
+          <div>
+            <Title order={3}>答え</Title>
+            <RichTextEditor
+              controls={[
+                ['bold', 'link', 'underline', 'italic'],
+                ['unorderedList', 'orderedList'],
+                ['h1', 'h2', 'h3'],
+              ]}
+              ref={editorRef}
+              value={faqData.answer}
+              onChange={(value) => handleEditorChange(value)}
+            />
+          </div>
           <Group style={{ margin: '20px 0' }}>
             <Button onClick={addFaq} disabled={isDisabled}>
               質問を増やす

--- a/package/src/components/EditStructuredData/EditFaqStructuredData.tsx
+++ b/package/src/components/EditStructuredData/EditFaqStructuredData.tsx
@@ -1,102 +1,24 @@
-import React, { useState, useEffect, useRef } from 'react';
-import ReactQuill from 'react-quill';
+import React from 'react';
 import { Button, Grid, Group, ScrollArea, TextInput, Title } from '@mantine/core';
 import { RichTextEditor } from '@mantine/rte';
 import ViewStructuredData from '~/components/common/ViewStructuredData';
 import FaqItem from '~/components/EditStructuredData/FaqItem';
 import { defaultfaqPageStructuredData } from '~/config/defaultStructuredData';
-import { FaqPageStructuredData } from '~/types/structuredData';
-import { escapeHtml } from '~/utils/escapeHtml';
+import { useFaq } from '~/hooks/useFaq';
 
 const EditFaqstructuredData: React.FC = () => {
-  const [structuredData, setStructuredData] = useState<FaqPageStructuredData>(defaultfaqPageStructuredData);
-  const [faqData, setFaqData] = useState({
-    question: '',
-    answer: '',
-  });
-  const [isDisabled, setIsDisabed] = useState(true);
-
-  const editorRef = useRef<ReactQuill | null>(null);
-
-  useEffect(() => {
-    // 答えを入力するテキストエディタの初期値が '<p><br></p>' になっている
-    if (faqData.question !== '' && faqData.answer !== '<p><br></p>') {
-      setIsDisabed(false);
-      return;
-    }
-
-    setIsDisabed(true);
-  }, [faqData]);
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFaqData({
-      ...faqData,
-      question: e.target.value,
-    });
-  };
-
-  const handleEditorChange = (answer: string) => {
-    setFaqData({
-      ...faqData,
-      answer,
-    });
-  };
-
-  // FAQを追加
-  const addFaq = () => {
-    setStructuredData({
-      ...structuredData,
-      mainEntity: [
-        ...structuredData.mainEntity,
-        {
-          '@type': 'Question',
-          name: faqData.question.trim(),
-          acceptedAnswer: {
-            '@type': 'Answer',
-            text: faqData.answer.trim().replace(/\r?\n/g, ''),
-          },
-        },
-      ],
-    });
-
-    // RichTextEditorの中身はDOMに直接アクセスしないと削除できなかったのでRefを使用する
-    if (!editorRef.current) return;
-
-    const editorHtml = editorRef.current.editingArea as Element;
-    if (editorHtml) {
-      const qlEditor = editorHtml.querySelector('.ql-editor');
-      if (qlEditor) qlEditor.innerHTML = '';
-    }
-    editorRef.current.value = '';
-
-    setFaqData({
-      question: '',
-      answer: '',
-    });
-  };
-
-  // FAQを削除
-  const removeFaq = (index: number) => {
-    const newStructuredData = [...structuredData.mainEntity].filter((_faq, faqIndex) => faqIndex !== index);
-    setStructuredData({
-      ...structuredData,
-      mainEntity: newStructuredData,
-    });
-  };
-
-  // FAQの構造化データの中の答えのHTMLのエスケープ化を行う
-  const escapeAnswerHtml = structuredData.mainEntity.map((entity) => {
-    return {
-      ...entity,
-      acceptedAnswer: {
-        '@type': 'Answer',
-        text: escapeHtml(entity.acceptedAnswer.text),
-      },
-    };
-  });
-
-  // プレビューに表示する構造化データの答えのみ上書きする
-  const newStructuredData = { ...structuredData, mainEntity: escapeAnswerHtml } as FaqPageStructuredData;
+  const {
+    structuredData,
+    setStructuredData,
+    faqData,
+    isDisabled,
+    editorRef,
+    handleInputChange,
+    handleEditorChange,
+    addFaq,
+    removeFaq,
+    newStructuredData,
+  } = useFaq();
 
   return (
     <>
@@ -109,7 +31,16 @@ const EditFaqstructuredData: React.FC = () => {
             value={faqData.question}
           />
           <Title order={3}>答え</Title>
-          <RichTextEditor ref={editorRef} value={faqData.answer} onChange={(value) => handleEditorChange(value)} />
+          <RichTextEditor
+            controls={[
+              ['bold', 'link', 'underline', 'italic'],
+              ['unorderedList', 'orderedList'],
+              ['h1', 'h2', 'h3'],
+            ]}
+            ref={editorRef}
+            value={faqData.answer}
+            onChange={(value) => handleEditorChange(value)}
+          />
           <Group style={{ margin: '20px 0' }}>
             <Button onClick={addFaq} disabled={isDisabled}>
               質問を増やす

--- a/package/src/components/EditStructuredData/FaqItem.tsx
+++ b/package/src/components/EditStructuredData/FaqItem.tsx
@@ -8,8 +8,6 @@ type Props = {
   removeQuestionAndAnswer: (index: number) => void;
 };
 
-// TODO: Answerは改行込みのデータを表示させる
-// 参考: https://qiita.com/ossan-engineer/items/bdb45368ab453af38342
 const FaqItem: React.FC<Props> = ({ faq, index, removeQuestionAndAnswer }) => {
   return (
     <Paper shadow="xs" p="sm" style={{ margin: '20px 0', position: 'relative' }}>
@@ -23,7 +21,7 @@ const FaqItem: React.FC<Props> = ({ faq, index, removeQuestionAndAnswer }) => {
       <Title order={3}>Question</Title>
       <Text>{faq.name}</Text>
       <Title order={3}>Answer</Title>
-      <Text>{faq.acceptedAnswer.text}</Text>
+      <Text dangerouslySetInnerHTML={{ __html: faq.acceptedAnswer.text }} />
     </Paper>
   );
 };

--- a/package/src/components/EditStructuredData/FaqItem.tsx
+++ b/package/src/components/EditStructuredData/FaqItem.tsx
@@ -13,7 +13,7 @@ const FaqItem: React.FC<Props> = ({ faq, index, removeQuestionAndAnswer }) => {
     <Paper shadow="xs" p="sm" style={{ margin: '20px 0', position: 'relative' }}>
       <CloseButton
         onClick={() => removeQuestionAndAnswer(index)}
-        style={{ position: 'absolute', top: '4px', right: '10px' }}
+        style={{ position: 'absolute', top: '8px', right: '18px' }}
         color="red"
         radius="xl"
         aria-label="FAQを削除する"

--- a/package/src/components/common/ViewStructuredData.tsx
+++ b/package/src/components/common/ViewStructuredData.tsx
@@ -7,12 +7,12 @@ import { copyToClipBoard } from '~/utils/copyToClipBoard';
 import { FaqPageStructuredData } from '~/types/structuredData';
 
 type Props = {
-  jsonString: FaqPageStructuredData;
+  structuredData: FaqPageStructuredData;
 };
 
-const ViewStructuredData: React.FC<Props> = ({ jsonString }) => {
+const ViewStructuredData = React.memo<Props>(({ structuredData }) => {
   const structuredDataCopy = () => {
-    copyToClipBoard(JSON.stringify(jsonString, null, 2));
+    copyToClipBoard(JSON.stringify(structuredData, null, 2));
 
     showNotification({
       title: 'クリップボードにコピーしました！',
@@ -37,7 +37,7 @@ const ViewStructuredData: React.FC<Props> = ({ jsonString }) => {
         </ActionIcon>
       </Tooltip>
       <CodeEditor
-        value={JSON.stringify(jsonString, null, 2)}
+        value={JSON.stringify(structuredData, null, 2)}
         language="json"
         padding={15}
         style={{
@@ -49,6 +49,6 @@ const ViewStructuredData: React.FC<Props> = ({ jsonString }) => {
       />
     </Box>
   );
-};
+});
 
 export default ViewStructuredData;

--- a/package/src/hooks/useFaq.ts
+++ b/package/src/hooks/useFaq.ts
@@ -1,0 +1,111 @@
+import { useState, useEffect, useRef } from 'react';
+import ReactQuill from 'react-quill';
+import { defaultfaqPageStructuredData } from '~/config/defaultStructuredData';
+import { FaqPageStructuredData } from '~/types/structuredData';
+import { escapeHtml } from '~/utils/escapeHtml';
+
+export const useFaq = () => {
+  const [structuredData, setStructuredData] = useState<FaqPageStructuredData>(defaultfaqPageStructuredData);
+  const [faqData, setFaqData] = useState({
+    question: '',
+    answer: '',
+  });
+  const [isDisabled, setIsDisabed] = useState(true);
+
+  const editorRef = useRef<ReactQuill | null>(null);
+
+  useEffect(() => {
+    // 答えを入力するテキストエディタの初期値が '<p><br></p>' になっている
+    if (faqData.question !== '' && faqData.answer !== '<p><br></p>') {
+      setIsDisabed(false);
+      return;
+    }
+
+    setIsDisabed(true);
+  }, [faqData]);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFaqData({
+      ...faqData,
+      question: e.target.value,
+    });
+  };
+
+  const handleEditorChange = (answer: string) => {
+    setFaqData({
+      ...faqData,
+      answer,
+    });
+  };
+
+  // FAQを追加
+  const addFaq = () => {
+    setStructuredData({
+      ...structuredData,
+      mainEntity: [
+        ...structuredData.mainEntity,
+        {
+          '@type': 'Question',
+          name: faqData.question.trim(),
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: faqData.answer,
+          },
+        },
+      ],
+    });
+
+    // RichTextEditorの中身はDOMに直接アクセスしないと削除できなかったのでRefを使用する
+    if (!editorRef.current) return;
+
+    const editorHtml = editorRef.current.editingArea as Element;
+
+    if (editorHtml) {
+      const qlEditor = editorHtml.querySelector('.ql-editor');
+
+      // エディターに入力した答えの初期化
+      if (qlEditor) qlEditor.innerHTML = '';
+    }
+
+    setFaqData({
+      question: '',
+      answer: '',
+    });
+  };
+
+  // FAQを削除
+  const removeFaq = (index: number) => {
+    const newStructuredData = [...structuredData.mainEntity].filter((_faq, faqIndex) => faqIndex !== index);
+    setStructuredData({
+      ...structuredData,
+      mainEntity: newStructuredData,
+    });
+  };
+
+  // FAQの構造化データの中の答えのHTMLのエスケープ化を行う
+  const escapeAnswerHtml = structuredData.mainEntity.map((entity) => {
+    return {
+      ...entity,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: escapeHtml(entity.acceptedAnswer.text),
+      },
+    };
+  });
+
+  // プレビューに表示する構造化データの答えのみ上書きする
+  const newStructuredData = { ...structuredData, mainEntity: escapeAnswerHtml } as FaqPageStructuredData;
+
+  return {
+    structuredData,
+    setStructuredData,
+    faqData,
+    isDisabled,
+    editorRef,
+    handleInputChange,
+    handleEditorChange,
+    addFaq,
+    removeFaq,
+    newStructuredData,
+  };
+};

--- a/package/src/utils/escapeHtml.ts
+++ b/package/src/utils/escapeHtml.ts
@@ -1,0 +1,23 @@
+// 置換対象の文字列
+// keyが置換前、valueが置換後
+const matchPattern = {
+  '&': '&amp;',
+  "'": '&#x27;',
+  '`': '&#x60;',
+  '"': '&quot;',
+  '<': '&lt;',
+  '>': '&gt;',
+};
+
+/**
+ * html文字列をエスケープする
+ * @param htmlText {string} - 置換対象のHTML文字列
+ */
+export const escapeHtml = (htmlText: string) => {
+  let result = htmlText;
+  for (const [key, value] of Object.entries(matchPattern)) {
+    const reg = new RegExp(key, 'g');
+    result = result.replace(reg, value);
+  }
+  return result;
+};

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -434,6 +434,15 @@
   dependencies:
     react-transition-group "^4.4.2"
 
+"@mantine/rte@^4.2.6":
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/@mantine/rte/-/rte-4.2.6.tgz#e9ac41538d7fcf6765752725abb5c1c359d52f50"
+  integrity sha512-oGzkrOB7kGKSfHJIZZNvJ/Q9RI5YbFFkZyZ1Mu6rg4FAQFiWJlnzsdPbVNuQJ7gmk4Hbme/2NNFG8ShB1FPWAg==
+  dependencies:
+    "@modulz/radix-icons" "^4.0.0"
+    quill-mention "^3.0.8"
+    react-quill "2.0.0-beta.4"
+
 "@mantine/styles@4.2.6":
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/@mantine/styles/-/styles-4.2.6.tgz#e29fe7f763dddd0af9624aaa7c3fe4b4181688be"
@@ -445,6 +454,11 @@
     "@emotion/utils" "1.0.0"
     clsx "^1.1.1"
     csstype "3.0.9"
+
+"@modulz/radix-icons@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@modulz/radix-icons/-/radix-icons-4.0.0.tgz#628a7826a4569dd2e3331e266d8d2e26c7d6753c"
+  integrity sha512-d79T4cYvMGMocVC/q1WiMO578FPFfUoxmXIkduc8cUQAPDr7thuEV5HrCHhqqqkoVaYD0QPct180ilcNUyGPrg==
 
 "@popperjs/core@^2.9.3":
   version "2.11.5"
@@ -581,6 +595,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
 
+"@types/quill@^1.3.10":
+  version "1.3.10"
+  resolved "https://registry.yarnpkg.com/@types/quill/-/quill-1.3.10.tgz#dc1f7b6587f7ee94bdf5291bc92289f6f0497613"
+  integrity sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==
+  dependencies:
+    parchment "^1.1.2"
+
 "@types/react-dom@^18.0.0":
   version "18.0.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.3.tgz#a022ea08c75a476fe5e96b675c3e673363853831"
@@ -662,6 +683,14 @@ browserslist@^4.20.2:
     node-releases "^2.0.3"
     picocolors "^1.0.0"
 
+call-bind@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -705,6 +734,11 @@ character-reference-invalid@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz#85c66b041e43b47210faf401278abf808ac45cb9"
   integrity sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==
+
+clone@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
 clsx@^1.1.1:
   version "1.1.1"
@@ -769,6 +803,26 @@ decode-named-character-reference@^1.0.0:
   integrity sha512-YV/0HQHreRwKb7uBopyIkLG17jG6Sv2qUchk9qSoVJ2f+flwRsPNBO0hAnjt6mTNYUT+vw9Gy2ihXg4sUWPi2w==
   dependencies:
     character-entities "^2.0.0"
+
+deep-equal@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
+  integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
+  dependencies:
+    is-arguments "^1.0.4"
+    is-date-object "^1.0.1"
+    is-regex "^1.0.4"
+    object-is "^1.0.1"
+    object-keys "^1.1.1"
+    regexp.prototype.flags "^1.2.0"
+
+define-properties@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
+  integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
+  dependencies:
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
 
 dom-helpers@^5.0.1:
   version "5.2.1"
@@ -936,10 +990,20 @@ estree-walker@^2.0.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
-extend@^3.0.0:
+eventemitter3@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+  integrity sha1-teEHm1n7XhuidxwKmTvgYKWMmbo=
+
+extend@^3.0.0, extend@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
+fast-diff@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
+  integrity sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==
 
 find-root@^1.1.0:
   version "1.1.0"
@@ -956,10 +1020,24 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+functions-have-names@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
+  integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -970,6 +1048,25 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+has-property-descriptors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
+  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+  dependencies:
+    get-intrinsic "^1.1.1"
+
+has-symbols@^1.0.1, has-symbols@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
+
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+  dependencies:
+    has-symbols "^1.0.2"
 
 has@^1.0.3:
   version "1.0.3"
@@ -1079,6 +1176,14 @@ is-alphanumerical@^2.0.0:
     is-alphabetical "^2.0.0"
     is-decimal "^2.0.0"
 
+is-arguments@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
+  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -1096,6 +1201,13 @@ is-core-module@^2.8.1:
   dependencies:
     has "^1.0.3"
 
+is-date-object@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
+  integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-decimal@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-2.0.1.tgz#9469d2dc190d0214fd87d78b78caecc0cc14eef7"
@@ -1110,6 +1222,14 @@ is-plain-obj@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.0.0.tgz#06c0999fd7574edf5a906ba5644ad0feb3a84d22"
   integrity sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw==
+
+is-regex@^1.0.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
+  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -1135,6 +1255,11 @@ lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
+lodash@^4.17.4:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -1162,6 +1287,24 @@ object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+object-is@^1.0.1:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
+  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
+object-keys@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+parchment@^1.1.2, parchment@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/parchment/-/parchment-1.1.4.tgz#aeded7ab938fe921d4c34bc339ce1168bc2ffde5"
+  integrity sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -1257,6 +1400,34 @@ property-information@^6.0.0:
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.1.1.tgz#5ca85510a3019726cb9afed4197b7b8ac5926a22"
   integrity sha512-hrzC564QIl0r0vy4l6MvRLhafmUowhO/O3KgVSoXIbbA2Sz4j8HGpJc6T2cubRVwMwpdiG/vKGfhT4IixmKN9w==
 
+quill-delta@^3.6.2:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/quill-delta/-/quill-delta-3.6.3.tgz#b19fd2b89412301c60e1ff213d8d860eac0f1032"
+  integrity sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==
+  dependencies:
+    deep-equal "^1.0.1"
+    extend "^3.0.2"
+    fast-diff "1.1.2"
+
+quill-mention@^3.0.8:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/quill-mention/-/quill-mention-3.1.0.tgz#acf0bf21524b627e9304f63534e6d2b8c59ab4fd"
+  integrity sha512-uyjGK8QPJHEcjvNc3wUJy6a05Oiu+6JJ0N9SFAwjYHYThgMzlKucyD975fq28Mr1it8ZFRNiRMPa0sCiVOAEwA==
+  dependencies:
+    quill "^1.3.7"
+
+quill@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/quill/-/quill-1.3.7.tgz#da5b2f3a2c470e932340cdbf3668c9f21f9286e8"
+  integrity sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==
+  dependencies:
+    clone "^2.1.1"
+    deep-equal "^1.0.1"
+    eventemitter3 "^2.0.3"
+    extend "^3.0.2"
+    parchment "^1.1.4"
+    quill-delta "^3.6.2"
+
 react-dom@^18.0.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.1.0.tgz#7f6dd84b706408adde05e1df575b3a024d7e8a2f"
@@ -1282,6 +1453,15 @@ react-popper@^2.2.5:
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
+
+react-quill@2.0.0-beta.4:
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/react-quill/-/react-quill-2.0.0-beta.4.tgz#522bd2680dc55713068c6cac12f2bf2ccfebcd28"
+  integrity sha512-KyAHvAlPjP4xLElKZJefMth91Z6FbbXRvq9OSu6xN3KBaoasLP9p+3dcxg4Ywr4tBlpMGXcPszYSAgd5CpJ45Q==
+  dependencies:
+    "@types/quill" "^1.3.10"
+    lodash "^4.17.4"
+    quill "^1.3.7"
 
 react-refresh@^0.12.0:
   version "0.12.0"
@@ -1329,6 +1509,15 @@ regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
+
+regexp.prototype.flags@^1.2.0:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
+  integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    functions-have-names "^1.2.2"
 
 rehype-parse@^8.0.0, rehype-parse@^8.0.2:
   version "8.0.4"


### PR DESCRIPTION
## やったこと
* 答えを入力する部分をWysiwygエディターに変更
* 入力した答えのHTMLのエスケープ化

## なぜ必要なのか
**答えを入力する部分をWysiwygエディターに変更**

FAQの構造化データの答えにはHTMLを入力することが可能だからです。

**入力した答えのHTMLのエスケープ化**

エスケープ化を実施しないと、リッチリザルトのチェックツールで構造化データのテストを行ったときに構造化データとして認識されないからです。

## その他
faqのロジックが肥大化してきたので、フックとして切り分けた