### PR TITLE
feat: プレビューをスクロールできるようにして・Titleのラッパーコンポーネント作って

### DIFF
--- a/package/src/components/EditStructuredData/EditFaqStructuredData.tsx
+++ b/package/src/components/EditStructuredData/EditFaqStructuredData.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Button, Grid, Group, ScrollArea, TextInput, Title } from '@mantine/core';
+import { Button, Grid, Group, ScrollArea, TextInput } from '@mantine/core';
 import { RichTextEditor } from '@mantine/rte';
+import Heading from '~/components/common/Heading';
 import ViewStructuredData from '~/components/common/ViewStructuredData';
 import FaqItem from '~/components/EditStructuredData/FaqItem';
 import { defaultfaqPageStructuredData } from '~/config/defaultStructuredData';
@@ -22,18 +23,18 @@ const EditFaqstructuredData: React.FC = () => {
 
   return (
     <>
-      <Title order={2}>FAQの構造化データを入力してください</Title>
+      <Heading order={2}>FAQの構造化データを入力してください</Heading>
       <Grid grow>
         <Grid.Col md={1} lg={2}>
           <div>
-            <Title order={3}>質問</Title>
+            <Heading order={3}>質問</Heading>
             <TextInput
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(e)}
               value={faqData.question}
             />
           </div>
           <div>
-            <Title order={3}>答え</Title>
+            <Heading order={3}>答え</Heading>
             <RichTextEditor
               controls={[
                 ['bold', 'link', 'underline', 'italic'],

--- a/package/src/components/EditStructuredData/FaqItem.tsx
+++ b/package/src/components/EditStructuredData/FaqItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { CloseButton, Paper, Text, Title } from '@mantine/core';
+import { CloseButton, Paper, Text } from '@mantine/core';
+import Heading from '~/components/common/Heading';
 import { FaqPageStructuredData } from '~/types/structuredData';
 
 type Props = {
@@ -18,9 +19,9 @@ const FaqItem: React.FC<Props> = ({ faq, index, removeQuestionAndAnswer }) => {
         radius="xl"
         aria-label="FAQを削除する"
       />
-      <Title order={3}>Question</Title>
+      <Heading order={3}>Question</Heading>
       <Text>{faq.name}</Text>
-      <Title order={3}>Answer</Title>
+      <Heading order={3}>Answer</Heading>
       <Text dangerouslySetInnerHTML={{ __html: faq.acceptedAnswer.text }} />
     </Paper>
   );

--- a/package/src/components/common/Heading.tsx
+++ b/package/src/components/common/Heading.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Title, TitleOrder } from '@mantine/core';
+
+type Props = {
+  children: React.ReactNode;
+  order: TitleOrder;
+};
+
+// Titleのラッパーコンポーネント
+const Heading: React.FC<Props> = ({ children, order }) => {
+  const style = (order: TitleOrder): React.CSSProperties => {
+    if (order === 2) {
+      return {
+        fontSize: '18px',
+      };
+    } else {
+      return {
+        fontSize: '16px',
+      };
+    }
+  };
+
+  return (
+    <Title order={order} style={style(order)}>
+      {children}
+    </Title>
+  );
+};
+
+export default Heading;

--- a/package/src/components/common/ViewStructuredData.tsx
+++ b/package/src/components/common/ViewStructuredData.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import CodeEditor from '@uiw/react-textarea-code-editor';
-import { ActionIcon, Box, Tooltip } from '@mantine/core';
+import { ActionIcon, Box, Tooltip, ScrollArea } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { CircleCheck, Copy } from 'tabler-icons-react';
 import { copyToClipBoard } from '~/utils/copyToClipBoard';
@@ -36,17 +36,20 @@ const ViewStructuredData = React.memo<Props>(({ structuredData }) => {
           <Copy />
         </ActionIcon>
       </Tooltip>
-      <CodeEditor
-        value={JSON.stringify(structuredData, null, 2)}
-        language="json"
-        padding={15}
-        style={{
-          fontSize: 14,
-          backgroundColor: '#323639',
-          fontFamily: 'ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace',
-          borderRadius: '4px',
-        }}
-      />
+      <ScrollArea style={{ height: 250 }}>
+        <CodeEditor
+          readOnly
+          value={JSON.stringify(structuredData, null, 2)}
+          language="json"
+          padding={15}
+          style={{
+            fontSize: 14,
+            backgroundColor: '#323639',
+            fontFamily: 'ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace',
+            borderRadius: '4px',
+          }}
+        />
+      </ScrollArea>
     </Box>
   );
 });


### PR DESCRIPTION
## やったこと
* プレビューをスクロールできるようにして
* Titleのラッパーコンポーネント作って

## なぜ必要なのか
* 出力した構造化データが増えてくると、プレビューが縦に伸びてしまい、みづらくなってしまうからです。
* Titleのfont-sizeはデフォルトだと大きすぎるので、コンポーネントがわでまとめて適用した方がstyleタグを何度も書かずに済むからです。

## その他
mantineにはテーマの概念があるっぽいのでこっちで指定した方がいいかも、

https://mantine.dev/theming/extend-theme/