### PR TITLE
fix: php7.2系だと関数の引数の末尾にカンマがあるとエラーになっちゃったので修正。

### DIFF
--- a/structured-data-tool.php
+++ b/structured-data-tool.php
@@ -29,7 +29,7 @@ class StructuredDataTool
       'structured-data-tool', /* ページを開いたときのurl */
       [$this, 'home_page'], /* メニューに紐づく画面を描画するcallback関数 */
       'dashicons-media-text', /* アイコン */
-      3, /* 表示位置の優先度 */
+      3 /* 表示位置の優先度 */
     );
   }
 
@@ -43,7 +43,7 @@ class StructuredDataTool
       'manage_options', /* 権限 */
       'settings', /* ページを開いたときのURL */
       [$this, 'settings_page'], /* メニューに紐づく画面を描画するcallback関数 */
-      'dashicons-media-text', /* アイコン */
+      'dashicons-media-text' /* アイコン */
     );
   }
 

--- a/structured-data-tool.php
+++ b/structured-data-tool.php
@@ -33,7 +33,7 @@ class StructuredDataTool
     );
   }
 
-  // メインメニュー
+  // サブメニュー
   public function sub_menu()
   {
     add_submenu_page(


### PR DESCRIPTION
## やったこと
関数の引数の末尾にカンマがついていると、PHPの7.2系だとエラーが発生しプラグインが正常に動作しなくなった。

https://qiita.com/K-Shuuun/items/c48292cd4186a2c1c8fd

## なぜ必要なのか
プラグインが使用できないから。

## その他
コメントアウトの修正。